### PR TITLE
Require directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,6 +231,28 @@ exports.requireDir = function (directory) {
 };
 
 //
+// ### function requireDirLazily (directory)
+// #### @directory {string} Directory to require
+// Lazily requires all files and directories from `directory`, returning an
+// object with keys being filenames (without trailing `.js`) and respective
+// values (getters) being return values of `require(filename)`.
+//
+exports.requireDirLazily = function (directory) {
+  var result = {},
+      files = fs.readdirSync(directory);
+
+  files.forEach(function (file) {
+    if (file.substr(-3) == '.js') {
+      file = file.substr(0, file.length - 3);
+    }
+    result.__defineGetter__(file, function () {
+      return require(path.resolve(directory, file));
+    });
+  });
+  return result;
+};
+
+//
 // Extend the `utile` object with all methods from the
 // core node `util` methods
 //

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,6 +210,13 @@ exports.readJSONFileSync = function (file) {
   return JSON.parse(fs.readFileSync(file, 'utf-8'));
 };
 
+//
+// ### function requireDirectory (directory)
+// #### @directory {string} Directory to require
+// Requires all files and directories from `directory`, returning an object
+// with keys being filenames (without trailing `.js`) and respective values
+// being return values of `require(filename)`.
+//
 exports.requireDirectory = function (directory) {
   var result = {},
       files = fs.readdirSync(directory);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,9 @@
  *
  */
 
+var fs = require('fs'),
+    path = require('path');
+
 var utile = exports;
 
 //
@@ -185,8 +188,6 @@ exports.filter = function (obj, test) {
 //
 
 exports.readJSONFile = function (file, callback) {
-  var fs = require('fs');
-
   if ('function' != typeof callback)
     throw new Error('readJSONFile needs a callback');
   fs.readFile(file, 'utf-8', function (err, json) {
@@ -209,9 +210,22 @@ exports.readJSONFileSync = function (file) {
   return JSON.parse(fs.readFileSync(file, 'utf-8'));
 };
 
+exports.requireDirectory = function (directory) {
+  var result = {},
+      files = fs.readdirSync(directory);
+
+  files.forEach(function (file) {
+    if (file.substr(-3) == '.js') {
+      file = file.substr(0, file.length - 3);
+    }
+    result[file] = require(path.resolve(directory, file));
+  });
+  return result;
+};
 
 //
 // Extend the `utile` object with all methods from the
 // core node `util` methods
 //
 utile.mixin(utile, require('util'));
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,13 +211,13 @@ exports.readJSONFileSync = function (file) {
 };
 
 //
-// ### function requireDirectory (directory)
+// ### function requireDir (directory)
 // #### @directory {string} Directory to require
 // Requires all files and directories from `directory`, returning an object
 // with keys being filenames (without trailing `.js`) and respective values
 // being return values of `require(filename)`.
 //
-exports.requireDirectory = function (directory) {
+exports.requireDir = function (directory) {
   var result = {},
       files = fs.readdirSync(directory);
 

--- a/test/fixtures/require-directory/directory/index.js
+++ b/test/fixtures/require-directory/directory/index.js
@@ -1,0 +1,2 @@
+exports.me = 'directory/index.js';
+

--- a/test/fixtures/require-directory/helloWorld.js
+++ b/test/fixtures/require-directory/helloWorld.js
@@ -1,0 +1,2 @@
+exports.me = 'helloWorld.js';
+

--- a/test/helpers/macros.js
+++ b/test/helpers/macros.js
@@ -1,3 +1,11 @@
+/*
+ * macros.js: Test macros for `utile` module.
+ *
+ * (C) 2011, Nodejitsu Inc.
+ * MIT LICENSE
+ *
+ */
+
 var assert = require('assert');
 
 var macros = exports;

--- a/test/helpers/macros.js
+++ b/test/helpers/macros.js
@@ -14,3 +14,15 @@ macros.assertReadCorrectJSON = function (obj) {
   });
 };
 
+macros.assertDirectoryRequired = function (obj) {
+  assert.isObject(obj);
+  assert.deepEqual(obj, {
+    directory: {
+      me: 'directory/index.js'
+    },
+    helloWorld: {
+      me: 'helloWorld.js'
+    }
+  });
+};
+

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -7,8 +7,8 @@ var requireFixtures = path.join(__dirname, 'fixtures', 'require-directory');
 
 vows.describe('utile/require-directory').addBatch({
   'When using utile': {
-    'the `requireDirectory()` function': {
-      topic: utile.requireDirectory(requireFixtures),
+    'the `requireDir()` function': {
+      topic: utile.requireDir(requireFixtures),
       'should contain all wanted modules': function (obj) {
         assert.isObject(obj);
         assert.deepEqual(obj, {

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -1,3 +1,12 @@
+/*
+ * require-directory-test.js: Tests for `requireDir` and `requireDirLazily`
+ * methods.
+ *
+ * (C) 2011, Nodejitsu Inc.
+ * MIT LICENSE
+ *
+ */
+
 var assert = require('assert'),
     path = require('path'),
     vows = require('vows'),

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -1,0 +1,26 @@
+var assert = require('assert'),
+    path = require('path'),
+    vows = require('vows'),
+    utile = require('../');
+
+var requireFixtures = path.join(__dirname, 'fixtures', 'require-directory');
+
+vows.describe('utile/require-directory').addBatch({
+  'When using utile': {
+    'the `requireDirectory()` function': {
+      topic: utile.requireDirectory(requireFixtures),
+      'should contain all wanted modules': function (obj) {
+        assert.isObject(obj);
+        assert.deepEqual(obj, {
+          directory: {
+            me: 'directory/index.js'
+          },
+          helloWorld: {
+            me: 'helloWorld.js'
+          }
+        });
+      }
+    }
+  }
+}).export(module);
+

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     path = require('path'),
     vows = require('vows'),
+    macros = require('./helpers/macros'),
     utile = require('../');
 
 var requireFixtures = path.join(__dirname, 'fixtures', 'require-directory');
@@ -9,16 +10,15 @@ vows.describe('utile/require-directory').addBatch({
   'When using utile': {
     'the `requireDir()` function': {
       topic: utile.requireDir(requireFixtures),
-      'should contain all wanted modules': function (obj) {
+      'should contain all wanted modules': macros.assertDirectoryRequired
+    },
+    'the `requireDirLazily()` function': {
+      topic: utile.requireDirLazily(requireFixtures),
+      'should contain all wanted modules': macros.assertDirectoryRequired,
+      'all properties should be getters': function (obj) {
         assert.isObject(obj);
-        assert.deepEqual(obj, {
-          directory: {
-            me: 'directory/index.js'
-          },
-          helloWorld: {
-            me: 'helloWorld.js'
-          }
-        });
+        assert.isTrue(!!obj.__lookupGetter__('directory'));
+        assert.isTrue(!!obj.__lookupGetter__('helloWorld'));
       }
     }
   }


### PR DESCRIPTION
This seems a common practice in our code. Lets DRY it!

Two functions were added:
- `requireDir(dir)`, which returns an object with all files from `dir` required
- `requireDirLazily(dir)`, which returns an object with getters (which `require` the file) for all files from `dir`
