### PR TITLE
Mixin getters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,8 +152,12 @@ utile.mixin = function (target) {
   var objs = Array.prototype.slice.call(arguments, 1);
   objs.forEach(function (o) {
     Object.keys(o).forEach(function (attr) {
-      if (!o.__lookupGetter__(attr)) {
+      var getter = o.__lookupGetter__(attr);
+      if (!getter) {
         target[attr] = o[attr];
+      }
+      else {
+        target.__defineGetter__(attr, getter);
       }
     });
   });

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -24,6 +24,9 @@ obj2 = {
   baz: true,
   buzz: 'buzz' 
 };
+obj2.__defineGetter__('bazz', function () {
+  return 'bazz';
+});
  
 vows.describe('utile').addBatch({
   "When using utile": {
@@ -47,6 +50,8 @@ vows.describe('utile').addBatch({
       assert.isObject(mixed.bar);
       assert.isTrue(mixed.baz);
       assert.isString(mixed.buzz);
+      assert.isTrue(!!mixed.__lookupGetter__('bazz'));
+      assert.isString(mixed.bazz);
     },
     "the clone() method": function () {
       var clone = utile.clone(obj1);


### PR DESCRIPTION
Copy getters from mixed-in objects to `target`.

This allows us to mixin lazy requires (like we would in case of `flatiron.plugins` and `broadway.plugins` - [here](https://github.com/flatiron/flatiron/blob/master/lib/flatiron.js#L27)).
