### PR TITLE
lazy load improved

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,8 @@ Object.keys(util).forEach(function (key) {
 // Simple wrapper to `require('async')`.
 //
 utile.__defineGetter__('async', function () {
-  var lib = require('async');
-  Object.defineProperty(utile, 'async', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'async', {value: require('async')});
+  return utile.async;
 });
 
 //
@@ -35,9 +34,8 @@ utile.__defineGetter__('async', function () {
 // Simple wrapper to `require('mkdirp')`
 //
 utile.__defineGetter__('mkdirp', function () {
-  var lib = require('mkdirp');
-  Object.defineProperty(utile, 'mkdirp', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'mkdirp', {value: require('mkdirp')});
+  return utile.mkdirp;
 });
 
 //
@@ -45,9 +43,8 @@ utile.__defineGetter__('mkdirp', function () {
 // Simple wrapper to `require('rimraf')`
 //
 utile.__defineGetter__('rimraf', function () {
-  var lib = require('rimraf');
-  Object.defineProperty(utile, 'rimraf', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'rimraf', {value: require('rimraf')});
+  return utile.rimraf;
 });
 
 //
@@ -55,9 +52,8 @@ utile.__defineGetter__('rimraf', function () {
 // Simple wrapper to `require('ncp').ncp`
 //
 utile.__defineGetter__('cpr', function () {
-  var lib = require('ncp').ncp;
-  Object.defineProperty(utile, 'cpr', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'cpr', {value: require('ncp').ncp});
+  return utile.cpr;
 });
 
 //
@@ -65,9 +61,8 @@ utile.__defineGetter__('cpr', function () {
 // Lazy-loaded `file` module
 //
 utile.__defineGetter__('file', function () {
-  var lib = require('./file');
-  Object.defineProperty(utile, 'file', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'file', {value: require('./file')});
+  return utile.file;
 });
 
 //
@@ -75,9 +70,8 @@ utile.__defineGetter__('file', function () {
 // Lazy-loaded `base64` object
 //
 utile.__defineGetter__('base64', function () {
-  var lib = require('./base64');
-  Object.defineProperty(utile, 'base64', {value: lib});
-  return lib;
+  Object.defineProperty(utile, 'base64', {value: require('./base64')});
+  return utile.base64;
 });
 
 //

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,9 +153,13 @@ utile.mixin = function (target) {
   var objs = Array.prototype.slice.call(arguments, 1);
   objs.forEach(function (o) {
     Object.keys(o).forEach(function (attr) {
-      var getter = o.__lookupGetter__(attr);
-      if (!getter) {
+      var getter = o.__lookupGetter__(attr)
+          ,setter = o.__lookupSetter__(attr);
+      if (!getter && !setter) {
         target[attr] = o[attr];
+      }
+      else if(setter) {
+        target.__defineSetter__(attr, setter);
       }
       else {
         target.__defineGetter__(attr, getter);
@@ -165,6 +169,7 @@ utile.mixin = function (target) {
   
   return target;
 };
+
 
 //
 // ### function capitalize (str)
@@ -259,8 +264,7 @@ utile.requireDirLazy = function (directory) {
       file = file.substr(0, file.length - 3);
     }
     result.__defineGetter__(file, function () {
-      delete result[file];
-      return result[file] = require(path.resolve(directory, file));
+      return require(path.resolve(directory, file));
     });
   });
   return result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,9 @@ Object.keys(util).forEach(function (key) {
 // Simple wrapper to `require('async')`.
 //
 utile.__defineGetter__('async', function () {
-  return require('async');
+  var lib = require('async');
+  Object.defineProperty(utile, 'async', {value: lib});
+  return lib;
 });
 
 //
@@ -33,7 +35,9 @@ utile.__defineGetter__('async', function () {
 // Simple wrapper to `require('mkdirp')`
 //
 utile.__defineGetter__('mkdirp', function () {
-  return require('mkdirp');
+  var lib = require('mkdirp');
+  Object.defineProperty(utile, 'mkdirp', {value: lib});
+  return lib;
 });
 
 //
@@ -41,7 +45,9 @@ utile.__defineGetter__('mkdirp', function () {
 // Simple wrapper to `require('rimraf')`
 //
 utile.__defineGetter__('rimraf', function () {
-  return require('rimraf');
+  var lib = require('rimraf');
+  Object.defineProperty(utile, 'rimraf', {value: lib});
+  return lib;
 });
 
 //
@@ -49,7 +55,9 @@ utile.__defineGetter__('rimraf', function () {
 // Simple wrapper to `require('ncp').ncp`
 //
 utile.__defineGetter__('cpr', function () {
-  return require('ncp').ncp;
+  var lib = require('ncp').ncp;
+  Object.defineProperty(utile, 'cpr', {value: lib});
+  return lib;
 });
 
 //
@@ -57,7 +65,9 @@ utile.__defineGetter__('cpr', function () {
 // Lazy-loaded `file` module
 //
 utile.__defineGetter__('file', function () {
-  return require('./file');
+  var lib = require('./file');
+  Object.defineProperty(utile, 'file', {value: lib});
+  return lib;
 });
 
 //
@@ -65,7 +75,9 @@ utile.__defineGetter__('file', function () {
 // Lazy-loaded `base64` object
 //
 utile.__defineGetter__('base64', function () {
-  return require('./base64');
+  var lib = require('./base64');
+  Object.defineProperty(utile, 'base64', {value: lib});
+  return lib;
 });
 
 //

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,11 +158,9 @@ utile.mixin = function (target) {
       if (!getter && !setter) {
         target[attr] = o[attr];
       }
-      else if(setter) {
-        target.__defineSetter__(attr, setter);
-      }
       else {
-        target.__defineGetter__(attr, getter);
+        if (setter) target.__defineSetter__(attr, setter);
+        if (getter) target.__defineGetter__(attr, getter);
       }
     });
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,8 @@ Object.keys(util).forEach(function (key) {
 // Simple wrapper to `require('async')`.
 //
 utile.__defineGetter__('async', function () {
-  Object.defineProperty(utile, 'async', {value: require('async')});
-  return utile.async;
+  delete utile.async;
+  return utile.async = require('async');
 });
 
 //
@@ -34,8 +34,8 @@ utile.__defineGetter__('async', function () {
 // Simple wrapper to `require('mkdirp')`
 //
 utile.__defineGetter__('mkdirp', function () {
-  Object.defineProperty(utile, 'mkdirp', {value: require('mkdirp')});
-  return utile.mkdirp;
+  delete utile.mkdirp;
+  return utile.mkdirp = require('mkdirp');
 });
 
 //
@@ -43,8 +43,8 @@ utile.__defineGetter__('mkdirp', function () {
 // Simple wrapper to `require('rimraf')`
 //
 utile.__defineGetter__('rimraf', function () {
-  Object.defineProperty(utile, 'rimraf', {value: require('rimraf')});
-  return utile.rimraf;
+  delete utile.rimraf;
+  return utile.rimraf = require('rimraf');
 });
 
 //
@@ -52,8 +52,8 @@ utile.__defineGetter__('rimraf', function () {
 // Simple wrapper to `require('ncp').ncp`
 //
 utile.__defineGetter__('cpr', function () {
-  Object.defineProperty(utile, 'cpr', {value: require('ncp').ncp});
-  return utile.cpr;
+  delete utile.cpr;
+  return utile.cpr = require('ncp').ncp;
 });
 
 //
@@ -61,8 +61,8 @@ utile.__defineGetter__('cpr', function () {
 // Lazy-loaded `file` module
 //
 utile.__defineGetter__('file', function () {
-  Object.defineProperty(utile, 'file', {value: require('./file')});
-  return utile.file;
+  delete utile.file;
+  return utile.file = require('./file');
 });
 
 //
@@ -70,8 +70,8 @@ utile.__defineGetter__('file', function () {
 // Lazy-loaded `base64` object
 //
 utile.__defineGetter__('base64', function () {
-  Object.defineProperty(utile, 'base64', {value: require('./base64')});
-  return utile.base64;
+  delete utile.base64;
+  return utile.base64 = require('./base64');
 });
 
 //

--- a/lib/index.js
+++ b/lib/index.js
@@ -264,7 +264,8 @@ utile.requireDirLazy = function (directory) {
       file = file.substr(0, file.length - 3);
     }
     result.__defineGetter__(file, function () {
-      return require(path.resolve(directory, file));
+      delete result[file];
+      return result[file] = require(path.resolve(directory, file));
     });
   });
   return result;

--- a/lib/index.js
+++ b/lib/index.js
@@ -259,7 +259,8 @@ utile.requireDirLazy = function (directory) {
       file = file.substr(0, file.length - 3);
     }
     result.__defineGetter__(file, function () {
-      return require(path.resolve(directory, file));
+      delete result[file];
+      return result[file] = require(path.resolve(directory, file));
     });
   });
   return result;

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -23,12 +23,12 @@ vows.describe('utile/require-directory').addBatch({
     },
     'the `requireDirLazy()` function': {
       topic: utile.requireDirLazy(requireFixtures),
-      'should contain all wanted modules': macros.assertDirectoryRequired,
       'all properties should be getters': function (obj) {
         assert.isObject(obj);
         assert.isTrue(!!obj.__lookupGetter__('directory'));
         assert.isTrue(!!obj.__lookupGetter__('helloWorld'));
-      }
+      },
+      'should contain all wanted modules': macros.assertDirectoryRequired
     }
   }
 }).export(module);

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -27,6 +27,9 @@ obj2 = {
 obj2.__defineGetter__('bazz', function () {
   return 'bazz';
 });
+obj2.__defineSetter__('bazz', function() {
+  return 'bazz';
+});
 obj2.__defineSetter__('wat', function () {
   return 'wat';
 });
@@ -52,6 +55,7 @@ vows.describe('utile').addBatch({
       assert.isTrue(mixed.baz);
       assert.isString(mixed.buzz);
       assert.isTrue(!!mixed.__lookupGetter__('bazz'));
+      assert.isTrue(!!mixed.__lookupSetter__('bazz'));
       assert.isTrue(!!mixed.__lookupSetter__('wat'));
       assert.isString(mixed.bazz);
     },

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -27,6 +27,9 @@ obj2 = {
 obj2.__defineGetter__('bazz', function () {
   return 'bazz';
 });
+obj2.__defineSetter__('wat', function () {
+  return 'wat';
+});
  
 vows.describe('utile').addBatch({
   "When using utile": {
@@ -49,6 +52,7 @@ vows.describe('utile').addBatch({
       assert.isTrue(mixed.baz);
       assert.isString(mixed.buzz);
       assert.isTrue(!!mixed.__lookupGetter__('bazz'));
+      assert.isTrue(!!mixed.__lookupSetter__('wat'));
       assert.isString(mixed.bazz);
     },
     "the clone() method": function () {


### PR DESCRIPTION
even though nodejs caches modules on require(), code runs slightly slower when you call closures instead of accessing the object directly...

feel free to reject my pull request

bye

yawnt 

// update: tests are now working with the new lazy load version. utile.mixin can also copy setters now 
