### PR TITLE
Added inflection module for lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The `utile` modules exposes some simple utility methods:
 In addition to the methods that are built-in, utile includes a number of commonly used dependencies to reduce the number of includes in your package.json. These modules _are not eagerly loaded to be respectful of startup time,_ but instead are lazy-loaded getters on the `utile` object
 
 * `.async`: [Async utilities for node and the browser][0]
+* `.inflect`: [Customizable inflections for node.js][6]
 * `.mkdirp`: [Recursively mkdir, like mkdir -p, but in node.js][1]
 * `.rimraf`: [A rm -rf util for nodejs][2]
 * `.cpr`: [Asynchronous recursive file copying with Node.js][3]
@@ -82,3 +83,4 @@ All tests are written with [vows][4] and should be run with [npm][5]:
 [3]: https://github.com/avianflu/ncp
 [4]: https://vowsjs.org
 [5]: https://npmjs.org
+[6]: https://github.com/pksunkara/inflect

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,9 +219,7 @@ utile.mixin = function (target) {
 // #### @str {string} String to capitalize
 // Capitalizes the specified `str`.
 //
-utile.capitalize = function (str) {
-  return str && str[0].toUpperCase() + str.slice(1);
-};
+utile.capitalize = utile.inflect.camelize;
 
 //
 // ### function randomString (length)

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,12 +21,21 @@ Object.keys(util).forEach(function (key) {
 });
 
 //
-// @async {Object}
+// ### function async
 // Simple wrapper to `require('async')`.
 //
 utile.__defineGetter__('async', function () {
   delete utile.async;
   return utile.async = require('async');
+});
+
+//
+// ### function inflect
+// Simple wrapper to `require('i')`.
+//
+utile.__defineGetter__('inflect', function () {
+  delete utile.inflect;
+  return utile.inflect = require('i')();
 });
 
 //

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "async": "0.1.x",
+    "i": "0.3.x",
     "mkdirp": "0.x.x",
     "ncp": "0.2.x",
     "rimraf": "1.x.x"

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -74,6 +74,11 @@ vows.describe('utile').addBatch({
 
       utile.createPath(x, ['a','b','c'], r)
       assert.equal(x.a.b.c, r)
+    },
+    "the capitalize() method": function () {
+      assert.isFunction(utile.capitalize);
+      assert.equal(utile.capitalize('bullet'), 'Bullet');
+      assert.equal(utile.capitalize('bullet_train'), 'BulletTrain');
     }
   }
 }).export(module);


### PR DESCRIPTION
### Why adding this?

As per plan with charlie for flatiron, we are going to need inflections. But instead of adding it as a dependency in flatiron repository, I am adding it here because it looks like resourceful might use a bit of this in the future.
### Why `i` module and why not `lingo`?

`lingo` written by tj doesn't support custom inflections, where as this is the only module in npmjs which supports it. This way, we can have control over inflections.

@indexzero, Please take a decision on this.
