### PR TITLE
[minor] Remove dash from possible characters in a randomString

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,10 +185,12 @@ utile.capitalize = function (str) {
 // the return value is a string of length ⌈bits/6⌉ of characters
 // from the base64 alphabet.
 //
+// Note: Alphabet does not include '-' due to the possibility of this character at the beginning
+// of a cli parameter confusing arguments parsers.
 utile.randomString = function (length) {
   var chars, rand, i, ret, mod, bits;
 
-  chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+  chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_';
   ret = '';
   // standard 4
   mod = 4;

--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,7 @@ utile.randomString = function (length) {
   // standard 4
   mod = 4;
   // default is 16
-  bits = length * mod || 64;
+  bits = length * mod || 63;
 
   // in v8, Math.random() yields 32 pseudo-random bits (in spidermonkey it gives 53)
   while (bits > 0) {
@@ -203,7 +203,7 @@ utile.randomString = function (length) {
     rand = Math.floor(Math.random() * 0x100000000);
     //we use the top bits
     for (i = 26; i > 0 && bits > 0; i -= mod, bits -= mod) {
-      ret += chars[0x3F & rand >>> i];
+      ret += chars[0x3E & rand >>> i];
     }
   }
 


### PR DESCRIPTION
This helps avoid cases where a randomString used in a cli tool such as jitsu confuses options parsers by having the dash at the beginning. For example,

```
-6sOkYcS_qoYMA4O
```

is easily misinterpreted.

One thing to point out, though, is that these changes mean we're now technically generating base63 strings. I'm not sure what ramifications, if any, this has.
