### PR TITLE
Avoid the need for `utile.args(arguments).array` by using `Object.defineProperty`

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -6,10 +6,10 @@
  *
  */
 
-var utile = require('../lib/');
+var utile = require('./index');
 
 //
-// ### function utils.args(_args)
+// ### function args(_args)
 // #### _args {Arguments} Original function arguments
 //
 // Top-level method will accept a javascript "arguments" object (the actual keyword
@@ -17,36 +17,21 @@ var utile = require('../lib/');
 // representing the functions arguments
 //
 module.exports = function (_args) {
-  var args, _cb;
-
-  //
-  // Helper function which defines a non-enumarable
-  // data property on the Array returned.
-  //
-  function namedArgument(name, value) {
-    Object.defineProperty(args, name, {
-      enumerable: false,
-      value: value
-    });
-  }
-
-  //
-  // Convert the raw `_args` to a proper Array.
-  //
-  args = Array.prototype.slice.call(_args || []);
-
+  var args = utile.rargs(_args),
+      _cb;
+  
   //
   // Find and define the first argument
   //
-  namedArgument('first', args[0])
+  Object.defineProperty(args, 'first', { value: args[0] });
 
   //
   // Find and define any callback
   //
   _cb = args[args.length - 1] || args[args.length];
   if (typeof _cb === "function") {
-    namedArgument('callback', _cb);
-    namedArgument('cb', _cb);
+    Object.defineProperty(args, 'callback', { value: _cb });
+    Object.defineProperty(args, 'cb', { value: _cb });
     args.pop();
   }
 
@@ -54,8 +39,8 @@ module.exports = function (_args) {
   // Find and define the last argument
   //
   if (args.length) {
-    namedArgument('last', args[args.length -1]);
+    Object.defineProperty(args, 'last', { value: args[args.length - 1] });
   }
-  
+
   return args;
 };

--- a/lib/args.js
+++ b/lib/args.js
@@ -17,28 +17,45 @@ var utile = require('../lib/');
 // representing the functions arguments
 //
 module.exports = function (_args) {
-  var args = {},
-      _cb;
+  var args, _cb;
 
   //
-  // convert to proper array object
+  // Helper function which defines a non-enumarable
+  // data property on the Array returned.
   //
-  args.array = Array.prototype.slice.call(_args || []);
-
-  //
-  // find any callbacks
-  //
-  _cb = args.array[args.array.length - 1] || args.array[args.array.length];
-  if (typeof _cb === "function") {
-    args.callback = _cb;
-    args.cb = args.callback;
-    args.array.pop();
+  function namedArgument(name, value) {
+    Object.defineProperty(args, name, {
+      enumerable: false,
+      value: value
+    });
   }
 
   //
-  // find last argument
+  // Convert the raw `_args` to a proper Array.
   //
-  args.last = args.array[args.array.length - 1] ||  args.array[1] || args.array[0];
+  args = Array.prototype.slice.call(_args || []);
 
+  //
+  // Find and define the first argument
+  //
+  namedArgument('first', args[0])
+
+  //
+  // Find and define any callback
+  //
+  _cb = args[args.length - 1] || args[args.length];
+  if (typeof _cb === "function") {
+    namedArgument('callback', _cb);
+    namedArgument('cb', _cb);
+    args.pop();
+  }
+
+  //
+  // Find and define the last argument
+  //
+  if (args.length) {
+    namedArgument('last', args[args.length -1]);
+  }
+  
   return args;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,15 +91,19 @@ utile.__defineGetter__('base64', function () {
 // (the actual keyword "arguments" inside any scope) and return
 // back an Array.
 //
-utile.rargs = function (_args) {
+utile.rargs = function (_args, slice) {
+  if (!slice) {
+    slice = 0;
+  }
+  
   var len = (_args || []).length,
-      args = new Array(len),
+      args = new Array(len - slice),
       i;
   
   //
   // Convert the raw `_args` to a proper Array.
   //
-  for (i = 0; i < len; i++) {
+  for (i = slice; i < len; i++) {
     args[i] = _args[i];
   }
   
@@ -182,7 +186,7 @@ utile.createPath = function (obj, path, value) {
 // onto `target` and returns the resulting object.
 //
 utile.mixin = function (target) {
-  Array.prototype.slice.call(arguments, 1).forEach(function (o) {
+  utile.rargs(arguments, 1).forEach(function (o) {
     Object.keys(o).forEach(function (attr) {
       var getter = o.__lookupGetter__(attr),
           setter = o.__lookupSetter__(attr);

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ utile.rargs = function (_args, slice) {
   // Convert the raw `_args` to a proper Array.
   //
   for (i = slice; i < len; i++) {
-    args[i] = _args[i];
+    args[i - slice] = _args[i];
   }
   
   return args;

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,29 @@ utile.__defineGetter__('base64', function () {
 });
 
 //
+// ### function rargs(_args)
+// #### _args {Arguments} Original function arguments
+//
+// Top-level method will accept a javascript "arguments" object 
+// (the actual keyword "arguments" inside any scope) and return
+// back an Array.
+//
+utile.rargs = function (_args) {
+  var len = (_args || []).length,
+      args = new Array(len),
+      i;
+  
+  //
+  // Convert the raw `_args` to a proper Array.
+  //
+  for (i = 0; i < len; i++) {
+    args[i] = _args[i];
+  }
+  
+  return args;
+};
+
+//
 // ### function each (obj, iterator)
 // #### @obj {Object} Object to iterate over
 // #### @iterator {function} Continuation to use on each key. `function (value, key, object)`

--- a/test/function-args-test.js
+++ b/test/function-args-test.js
@@ -29,7 +29,7 @@ vows.describe('utile/args').addBatch({
     'should return an empty object': function (err, result) {
       assert.isNull(err);
       assert.isUndefined(result.callback);
-      assert.isObject(result);
+      assert.isArray(result);
     }
   },
   'util.args() with simple arguments': {
@@ -38,19 +38,34 @@ vows.describe('utile/args').addBatch({
       (function () {
         var result = utile.args(arguments);
         that.callback(null, result);
-      })("a", "b", "c", function () { 
+      })('a', 'b', 'c', function () { 
         return 'ok';
       })
     },
     'should return an array with three items': function (err, result) {
       assert.isNull(err);
-      assert.isArray(result.array);
-      assert.equal(3, result.array.length);
+      assert.isArray(result);
+      assert.equal(3, result.length);
+      assert.equal(result[0], 'a');
+      assert.equal(result[1], 'b');
+      assert.equal(result[2], 'c');
+      
+      //
+      // Ensure that the Array returned
+      // by `utile.args()` enumerates correctly
+      //
+      var length = 0;
+      result.forEach(function (item) {
+        length++;
+      });
+      
+      assert.equal(length, 3);
     },
     'should return lookup helpers': function (err, result) {
       assert.isNull(err);
-      assert.isObject(result);
-      assert.equal(result.last, "c");
+      assert.isArray(result);
+      assert.equal(result.first, 'a');
+      assert.equal(result.last, 'c');
       assert.isFunction(result.callback);
       assert.isFunction(result.cb);
     }

--- a/test/function-args-test.js
+++ b/test/function-args-test.js
@@ -21,53 +21,84 @@ vows.describe('utile/args').addBatch({
       },
     }
   },
-  'util.args() with no arguments': {
-    topic: function () {
-      var result = utile.args();
-      this.callback(null, result);
+  'utile.rargs()': {
+    'with no arguments': {
+      topic: utile.rargs(),
+      'should return an empty object': function (result) {
+        assert.isArray(result);
+        assert.lengthOf(result, 0);
+      }
     },
-    'should return an empty object': function (err, result) {
-      assert.isNull(err);
-      assert.isUndefined(result.callback);
-      assert.isArray(result);
+    'with simple arguments': {
+      topic: function () {
+        return (function () {
+          return utile.rargs(arguments);
+        })('a', 'b', 'c');
+      },
+      'should return an array with three items': function (result) {
+        assert.isArray(result);
+        assert.equal(3, result.length);
+        assert.equal(result[0], 'a');
+        assert.equal(result[1], 'b');
+        assert.equal(result[2], 'c');
+      }
+    },
+    'with a simple slice': {
+      topic: function () {
+        return (function () {
+          return utile.rargs(arguments, 1);
+        })('a', 'b', 'c');
+      },
+      'should return an array with three items': function (result) {
+        assert.isArray(result);
+        assert.equal(2, result.length);
+        assert.equal(result[0], 'b');
+        assert.equal(result[1], 'c');
+      }
     }
   },
-  'util.args() with simple arguments': {
-    topic: function () {
-      var that = this;
-      (function () {
-        var result = utile.args(arguments);
-        that.callback(null, result);
-      })('a', 'b', 'c', function () { 
-        return 'ok';
-      })
+  'utile.args()': {
+    'with no arguments': {
+      topic: utile.args(),
+      'should return an empty Array': function (result) {
+        assert.isUndefined(result.callback);
+        assert.isArray(result);
+        assert.lengthOf(result, 0);
+      }
     },
-    'should return an array with three items': function (err, result) {
-      assert.isNull(err);
-      assert.isArray(result);
-      assert.equal(3, result.length);
-      assert.equal(result[0], 'a');
-      assert.equal(result[1], 'b');
-      assert.equal(result[2], 'c');
-      
-      //
-      // Ensure that the Array returned
-      // by `utile.args()` enumerates correctly
-      //
-      var length = 0;
-      result.forEach(function (item) {
-        length++;
-      });
-      
-      assert.equal(length, 3);
-    },
-    'should return lookup helpers': function (err, result) {
-      assert.isNull(err);
-      assert.isArray(result);
-      assert.equal(result.first, 'a');
-      assert.equal(result.last, 'c');
-      assert.isFunction(result.callback);
-      assert.isFunction(result.cb);
+    'with simple arguments': {
+      topic: function () {
+        return (function () {
+          return utile.args(arguments);
+        })('a', 'b', 'c', function () { 
+          return 'ok';
+        });
+      },
+      'should return an array with three items': function (result) {
+        assert.isArray(result);
+        assert.equal(3, result.length);
+        assert.equal(result[0], 'a');
+        assert.equal(result[1], 'b');
+        assert.equal(result[2], 'c');
+
+        //
+        // Ensure that the Array returned
+        // by `utile.args()` enumerates correctly
+        //
+        var length = 0;
+        result.forEach(function (item) {
+          length++;
+        });
+
+        assert.equal(length, 3);
+      },
+      'should return lookup helpers': function (result) {
+        assert.isArray(result);
+        assert.equal(result.first, 'a');
+        assert.equal(result.last, 'c');
+        assert.isFunction(result.callback);
+        assert.isFunction(result.cb);
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
Discussed this with @marak over gchat the other day and decided to implement it.

imho we should be optimizing for the simple case where someone simply wants to call `Array.prototype.slice.call(arguments)`. Check the diff on the tests for all the details of what's changing.

**Usage:**

``` js
  function getArgs() {
    //
    // [ 'a', 'b', 'c' ]
    //
    console.dir(utile.args(arguments));

    //
    // All additional properties not enumerable.
    // e.g. 
    //

    //
    // function ok() { console.log('ok');
    //
    console.dir(utile.args(arguments).cb.toString());
  }
```
