### PR TITLE
Remove deprecated code.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,88 +20,102 @@ Object.keys(util).forEach(function (key) {
   utile[key] = util[key];
 });
 
-//
-// ### function async
-// Simple wrapper to `require('async')`.
-//
-utile.__defineGetter__('async', function () {
-  delete utile.async;
-  return utile.async = require('async');
+Object.defineProperties(utile, {
+
+  //
+  // ### function async
+  // Simple wrapper to `require('async')`.
+  //
+  'async': {
+    get: function() {
+      return utile.async = require('async');
+    }
+  },
+
+  //
+  // ### function inflect
+  // Simple wrapper to `require('i')`.
+  //
+  'inflect': {
+    get: function() {
+      return utile.inflect = require('i')();
+    }
+  },
+
+  //
+  // ### function mkdirp
+  // Simple wrapper to `require('mkdirp')`
+  //
+  'mkdirp': {
+    get: function() {
+      return utile.mkdirp = require('mkdirp');
+    }
+  },
+
+  //
+  // ### function deepEqual
+  // Simple wrapper to `require('deep-equal')`
+  // Remark: deepEqual is 4x faster then using assert.deepEqual
+  //         see: https://gist.github.com/2790507
+  //
+  'deepEqual': {
+    get: function() {
+      return utile.deepEqual = require('deep-equal');
+    }
+  },
+
+  //
+  // ### function rimraf
+  // Simple wrapper to `require('rimraf')`
+  //
+  'rimraf': {
+    get: function() {
+      return utile.rimraf = require('rimraf');
+    }
+  },
+
+  //
+  // ### function cpr
+  // Simple wrapper to `require('ncp').ncp`
+  //
+  'cpr': {
+    get: function() {
+      return utile.cpr = require('ncp').ncp;
+    }
+  },
+
+  //
+  // ### @file {Object}
+  // Lazy-loaded `file` module
+  //
+  'file': {
+    get: function() {
+      return utile.file = require('./file');
+    }
+  },
+
+  //
+  // ### @args {Object}
+  // Lazy-loaded `args` module
+  //
+  'args': {
+    get: function() {
+      return utile.args = require('./args');
+    }
+  },
+
+  //
+  // ### @base64 {Object}
+  // Lazy-loaded `base64` object
+  //
+  'base64': {
+    get: function() {
+      return utile.base64 = require('./base64');
+    }
+  }
+
 });
 
-//
-// ### function inflect
-// Simple wrapper to `require('i')`.
-//
-utile.__defineGetter__('inflect', function () {
-  delete utile.inflect;
-  return utile.inflect = require('i')();
-});
-
-//
-// ### function mkdirp
-// Simple wrapper to `require('mkdirp')`
-//
-utile.__defineGetter__('mkdirp', function () {
-  delete utile.mkdirp;
-  return utile.mkdirp = require('mkdirp');
-});
-
-//
-// ### function deepEqual
-// Simple wrapper to `require('deep-equal')`
-// Remark: deepEqual is 4x faster then using assert.deepEqual
-//         see: https://gist.github.com/2790507
-//
-utile.__defineGetter__('deepEqual', function () {
-  delete utile.deepEqual;
-  return utile.deepEqual = require('deep-equal');
-});
-
-//
-// ### function rimraf
-// Simple wrapper to `require('rimraf')`
-//
-utile.__defineGetter__('rimraf', function () {
-  delete utile.rimraf;
-  return utile.rimraf = require('rimraf');
-});
-
-//
-// ### function cpr
-// Simple wrapper to `require('ncp').ncp`
-//
-utile.__defineGetter__('cpr', function () {
-  delete utile.cpr;
-  return utile.cpr = require('ncp').ncp;
-});
-
-//
-// ### @file {Object}
-// Lazy-loaded `file` module
-//
-utile.__defineGetter__('file', function () {
-  delete utile.file;
-  return utile.file = require('./file');
-});
-
-//
-// ### @args {Object}
-// Lazy-loaded `args` module
-//
-utile.__defineGetter__('args', function () {
-  delete utile.args;
-  return utile.args = require('./args');
-});
-
-//
-// ### @base64 {Object}
-// Lazy-loaded `base64` object
-//
-utile.__defineGetter__('base64', function () {
-  delete utile.base64;
-  return utile.base64 = require('./base64');
-});
 
 //
 // ### function rargs(_args)
@@ -229,16 +243,18 @@ utile.createPath = function (obj, path, value) {
 //
 utile.mixin = function (target) {
   utile.rargs(arguments, 1).forEach(function (o) {
-    Object.keys(o).forEach(function (attr) {
-      var getter = o.__lookupGetter__(attr),
-          setter = o.__lookupSetter__(attr);
+    Object.getOwnPropertyNames(o).forEach(function(attr) {
+      var getter = Object.getOwnPropertyDescriptor(o, attr).get,
+          setter = Object.getOwnPropertyDescriptor(o, attr).set;
 
       if (!getter && !setter) {
         target[attr] = o[attr];
       }
       else {
-        if (setter) { target.__defineSetter__(attr, setter) }
-        if (getter) { target.__defineGetter__(attr, getter) }
+        Object.defineProperty(target, attr, {
+          get: getter,
+          set: setter
+        });
       }
     });
   });
@@ -346,11 +362,13 @@ utile.requireDirLazy = function (directory) {
     if (file.substr(-3) === '.js') {
       file = file.substr(0, file.length - 3);
     }
-    result.__defineGetter__(file, function () {
-      delete result[file];
-      return result[file] = require(path.resolve(directory, file));
+    Object.defineProperty(result, file, {
+      get: function() {
+        return result[file] = require(path.resolve(directory, file));
+      }
     });
   });
+  
   return result;
 };
 

--- a/test/helpers/macros.js
+++ b/test/helpers/macros.js
@@ -6,13 +6,14 @@
  *
  */
 
-var assert = require('assert');
+var assert = require('assert'),
+    utile = require('../../lib');
 
 var macros = exports;
 
 macros.assertReadCorrectJson = function (obj) {
   assert.isObject(obj);
-  assert.deepEqual(obj, {
+  utile.deepEqual(obj, {
     hello: 'World',
     'I am': ['the utile module'],
     thisMakesMe: {
@@ -24,7 +25,7 @@ macros.assertReadCorrectJson = function (obj) {
 
 macros.assertDirectoryRequired = function (obj) {
   assert.isObject(obj);
-  assert.deepEqual(obj, {
+  utile.deepEqual(obj, {
     directory: {
       me: 'directory/index.js'
     },

--- a/test/require-directory-test.js
+++ b/test/require-directory-test.js
@@ -25,8 +25,8 @@ vows.describe('utile/require-directory').addBatch({
       topic: utile.requireDirLazy(requireFixtures),
       'all properties should be getters': function (obj) {
         assert.isObject(obj);
-        assert.isTrue(!!obj.__lookupGetter__('directory'));
-        assert.isTrue(!!obj.__lookupGetter__('helloWorld'));
+        assert.isTrue(!!Object.getOwnPropertyDescriptor(obj, 'directory').get);
+        assert.isTrue(!!Object.getOwnPropertyDescriptor(obj, 'helloWorld').get);
       },
       'should contain all wanted modules': macros.assertDirectoryRequired
     }

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -25,16 +25,24 @@ obj2 = {
   buzz: 'buzz'
 };
 
-obj2.__defineGetter__('bazz', function () {
-  return 'bazz';
-});
+Object.defineProperties(obj2, {
 
-obj2.__defineSetter__('bazz', function () {
-  return 'bazz';
-});
+  'bazz': {
+    get: function() {
+      return 'bazz';
+    },
 
-obj2.__defineSetter__('wat', function () {
-  return 'wat';
+    set: function() {
+      return 'bazz';
+    }
+  },
+
+  'wat': {
+    set: function() {
+      return 'wat';
+    }
+  }
+
 });
 
 vows.describe('utile').addBatch({
@@ -57,9 +65,9 @@ vows.describe('utile').addBatch({
       assert.isObject(mixed.bar);
       assert.isTrue(mixed.baz);
       assert.isString(mixed.buzz);
-      assert.isTrue(!!mixed.__lookupGetter__('bazz'));
-      assert.isTrue(!!mixed.__lookupSetter__('bazz'));
-      assert.isTrue(!!mixed.__lookupSetter__('wat'));
+      assert.isTrue(!!Object.getOwnPropertyDescriptor(mixed, 'bazz').get);
+      assert.isTrue(!!Object.getOwnPropertyDescriptor(mixed, 'bazz').set);
+      assert.isTrue(!!Object.getOwnPropertyDescriptor(mixed, 'wat').set);
       assert.isString(mixed.bazz);
     },
     "the clone() method": function () {


### PR DESCRIPTION
Get rid of `__defineGetter__`, `__defineSetter__`, `__lookupSetter__`, and `__lookupGetter__`.
