### PR TITLE
Add proxy method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -445,3 +445,31 @@ utile.underscoreToCamel = function (obj) {
 
   return obj;
 };
+
+//
+// ### function proxy (fn, context)
+// #### @fn {Function} Function to proxy to.
+// #### @context {Object} Object that will be the context.
+// Proxies a function to maintain the context passed
+//
+utile.proxy = function (fn, context) {
+    var tmp, args, proxy;
+
+    if (typeof context === "string") {
+        tmp = fn[context];
+        context = fn;
+        fn = tmp;
+    }
+
+    if (typeof fn !== 'function') {
+        return undefined;
+    }
+
+    args = Array.prototype.slice.call(arguments, 2);
+
+    proxy = function () {
+        return fn.apply(context, args.concat(Array.prototype.slice.call(arguments)));
+    };
+
+    return proxy;
+};

--- a/test/utile-test.js
+++ b/test/utile-test.js
@@ -120,7 +120,25 @@ vows.describe('utile').addBatch({
       assert.isObject(obj.key_with_camel);
       assert.isString(obj.just_one);
       assert.isTrue(obj.key_with_camel.nested_camel);
-    }
+    },
+      "the proxy() method": {
+	  "should have the right context": function() {
+	      var fn = utile.proxy(function() {
+		  assert.isObject(this);
+		  assert.deepEqual(this, { test:'ing' });
+	      }, { test:'ing' });
+
+	      fn();
+	  },
+	  "should have the right arguments": function() {
+	      var fn = utile.proxy(function(one, two) {
+		  assert.equal(one, 'one');
+		  assert.equal(two, 'two');
+	      }, {}, 'one');
+
+	      fn('two');
+	  }
+      }
   }
 }).export(module);
 


### PR DESCRIPTION
I find myself using a proxy method a lot to maintain context on an event. I like to have event handlers has a object method, but still maintain `this`. Adding a proxy method make it simple to do, here is an example:

``` javascript
var net = require('net'),
utile = require('utile');

var Obj = function() {
    //instead of:
    // var self = this;
    // self.socket = net.connect({port:8124}, function() { self._onConnect.apply(self, arguments); });

    //just use:
    this.socket = net.connect({port: 8124}, utile.proxy(this._onConnect, this));
};

Obj.prototype._onConnect = function() {
    //'this' is the Obj instance as it should be, even
    //when it is called as the callback for connect
};
```

The code for this pull request was based on the [`jQuery.proxy()`](http://api.jquery.com/jQuery.proxy/) method ([source here](http://james.padolsey.com/jquery/#v=git&fn=jQuery.proxy))
