### PR TITLE
Format enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The `utile` modules exposes some simple utility methods:
 * `.filter(obj, test)`: return an object with the properties that `test` returns true on.
 * `.args(arguments)`: Converts function arguments into actual array with special `callback`, `cb`, `array`, and `last` properties. Also supports *optional* argument contracts. See [the example](https://github.com/flatiron/utile/blob/master/examples/utile-args.js) for more details.
 * `.requireDir(directory)`: Requires all files and directories from `directory`, returning an object with keys being filenames (without trailing `.js`) and respective values being return values of `require(filename)`.
-* `.requireDirLazy(directoy)`: Lazily requires all files and directories from `directory`, returning an object with keys being filenames (without trailing `.js`) and respective values (getters) being return values of `require(filename)`.
+* `.requireDirLazy(directory)`: Lazily requires all files and directories from `directory`, returning an object with keys being filenames (without trailing `.js`) and respective values (getters) being return values of `require(filename)`.
+* `.format([string] text, [array] formats, [array] replacements)`: Replace `formats` in `text` with `replacements`. This will fall back to the original `util.format` command if it is called improperly.
 
 ## Packaged Dependencies
 In addition to the methods that are built-in, utile includes a number of commonly used dependencies to reduce the number of includes in your package.json. These modules _are not eagerly loaded to be respectful of startup time,_ but instead are lazy-loaded getters on the `utile` object

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,0 +1,25 @@
+/*
+ * format.js: `util.format` enhancement to allow custom formatting parameters.
+ *
+ * (C) 2012, Nodejitsu Inc.
+ * MIT LICENSE
+ *
+ */
+
+var util = require('util');
+
+exports = module.exports = function(str) {
+  var formats = [].slice.call(arguments, 1, 3);
+
+  if (!(formats[0] instanceof Array && formats[1] instanceof Array) || arguments.length > 3)
+    return util.format.apply(null, arguments);
+
+  var replacements = formats.pop(),
+      formats = formats.shift();
+
+  formats.forEach(function(format, id) {
+    str = str.replace(new RegExp(format), replacements[id]);
+  });
+
+  return str;
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,16 @@ Object.defineProperties(utile, {
     get: function() {
       return utile.base64 = require('./base64');
     }
+  },
+
+  //
+  // ### @format {Object}
+  // Lazy-loaded `format` object
+  //
+  'format': {
+    get: function() {
+      return utile.format = require('./format');
+    }
   }
 
 });

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -1,0 +1,31 @@
+/*
+ * format-test.js: Tests for `utile.format` module.
+ *
+ * (C) 2011, Nodejitsu Inc.
+ * MIT LICENSE
+ *
+ */
+
+var vows = require('vows'),
+    assert = require('assert'),
+    utile = require('../lib');
+
+vows.describe('utile/format').addBatch({
+
+  'Should use the original `util.format` if there are no custom parameters to replace.': function() {
+    assert.equal(utile.format('%s %s %s', 'test', 'test2', 'test3'), 'test test2 test3');
+  },
+
+  'Should use `utile.format` if custom parameters are provided.': function() {
+    assert.equal(utile.format('%a %b %c', [
+      '%a',
+      '%b',
+      '%c'
+    ], [
+      'test',
+      'test2',
+      'test3'
+    ]), 'test test2 test3');
+  }
+
+}).export(module);


### PR DESCRIPTION
Adds the ability to format with custom tags.

``` js
var utile = require('utile');

console.log(utile.format('%a %b %c', [
  '%a',
  '%b',
  '%c'
], [
  'test',
  'test2',
  'test3'
]));
```
