### PR TITLE
Filter no longer creates a sparse array as a result when passed an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 npm-debug.log
+*.swp
+*.swo

--- a/lib/index.js
+++ b/lib/index.js
@@ -327,13 +327,23 @@ utile.randomString = function (length) {
 // the predicate `pred`
 //
 utile.filter = function (obj, pred) {
-  var copy = Array.isArray(obj) ? [] : {};
-  utile.each(obj, function (val, key) {
-    if (pred(val, key, obj)) {
-      copy[key] = val;
-    }
-  });
-
+  var copy;
+  if (Array.isArray(obj)) {
+    copy = [];
+    utile.each(obj, function (val, key) {
+      if (pred(val, key, obj)) {
+        copy.push(val);
+      }
+    });
+  }
+  else {
+    copy = {};
+    utile.each(obj, function (val, key) {
+      if (pred(val, key, obj)) {
+        copy[key] = val;
+      }
+    });
+  }
   return copy;
 };
 


### PR DESCRIPTION
When one passes an array into utile.filter, it uses the key which is the array index. It reassigns the values for which pred is true to the key.  It instead should just return a collapsed result by simply pushing the successful value into the new array. 
