### PR TITLE
Dot files and dirs should be ignored with requireDir and requireDirLazy.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -359,6 +359,10 @@ utile.requireDir = function (directory) {
       files = fs.readdirSync(directory);
 
   files.forEach(function (file) {
+    if (file[0] === '.') {
+      return;
+    }
+
     if (file.substr(-3) === '.js') {
       file = file.substr(0, file.length - 3);
     }
@@ -379,6 +383,10 @@ utile.requireDirLazy = function (directory) {
       files = fs.readdirSync(directory);
 
   files.forEach(function (file) {
+    if (file[0] === '.') {
+      return;
+    }
+
     if (file.substr(-3) === '.js') {
       file = file.substr(0, file.length - 3);
     }

--- a/test/fixtures/require-directory/.dot_directory/.gitignore
+++ b/test/fixtures/require-directory/.dot_directory/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/test/fixtures/require-directory/.dot_file.js
+++ b/test/fixtures/require-directory/.dot_file.js
@@ -1,0 +1,2 @@
+exports.me = 'dot_file.js';
+


### PR DESCRIPTION
This should fix #23.
