### PR TITLE
Bump async version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://github.com/flatiron/utile.git"
   },
   "dependencies": {
-    "async": "~1.0.0",
+    "async": "^1.0.0",
     "deep-equal": "~0.2.1",
     "i": "0.3.x",
     "mkdirp": "0.x.x",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://github.com/flatiron/utile.git"
   },
   "dependencies": {
-    "async": "~0.9.0",
+    "async": "~1.0.0",
     "deep-equal": "~0.2.1",
     "i": "0.3.x",
     "mkdirp": "0.x.x",


### PR DESCRIPTION
https://github.com/caolan/async/blob/master/CHANGELOG.md#v100

`async` is now at `1.0.0` version, the changes shouldn't include breaking changes.
