### PR TITLE
[fix] Fixed uninitialized buffer vulnerability in base64 methods. (https://hackerone.com/reports/321701)

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -16,7 +16,7 @@ base64.encode = function (unencoded) {
   var encoded;
 
   try {
-    encoded = new Buffer(unencoded || '').toString('base64');
+    encoded = new Buffer(unencoded ? String(unencoded) : '').toString('base64');
   }
   catch (ex) {
     return null;
@@ -34,7 +34,7 @@ base64.decode = function (encoded) {
   var decoded;
 
   try {
-    decoded = new Buffer(encoded || '', 'base64').toString('utf8');
+    decoded = new Buffer(encoded ? String(encoded) : '', 'base64').toString('utf8');
   }
   catch (ex) {
     return null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "utile",
   "description": "A drop-in replacement for `util` with some additional advantageous functions",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers": [
     "indexzero <charlie@nodejitsu.com>"

--- a/test/base64-test.js
+++ b/test/base64-test.js
@@ -1,0 +1,17 @@
+var assert = require('assert'),
+    vows = require('vows'),
+    utile = require('../lib/');
+
+
+vows.describe('utile/base64').addBatch({
+
+  'Should treat input as a string for encode().': function() {
+    assert.equal(utile.base64.encode('200'), utile.base64.encode(200))
+    assert.equal(utile.base64.encode('100000000'), utile.base64.encode(1e8))
+  },
+
+  'Should treat input as a string for decode().': function() {
+    assert.equal(utile.base64.decode('MTAw'), 100)
+  }
+
+}).export(module);


### PR DESCRIPTION
# Remediation
The source code in base64.js says that both encode¹ and decode² expect a string parameter. I see two obvious solutions.

1. Return null when base64.encode or base64.decode are given something other than a string.
2. Convert the parameter passed into base64.encode and base64.decode into a string before encoding or decoding.

To preserve backward compatibility with existing usage that might not be expecting null as a return value from encoding or decoding values that are not strings, I think we should covert the parameter to a string then perform that encode or decode operation.

¹ https://github.com/flatiron/utile/blob/master/lib/base64.js#L12
² https://github.com/flatiron/utile/blob/master/lib/base64.js#L30